### PR TITLE
Bug fix #(all tasks showing across different project)

### DIFF
--- a/backend/src/main/java/com/collab/taskmanager/repos/TaskRepo.java
+++ b/backend/src/main/java/com/collab/taskmanager/repos/TaskRepo.java
@@ -9,8 +9,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TaskRepo extends JpaRepository<Task, Long> {
-    Page<Task> findAllByProjectId(Long projectId, Pageable pageable);
+    Page<Task> findAllByProject_Id(Long projectId, Pageable pageable);
+    List<Task> findByAssignedUser_IdAndProject_Id(Long userId, Long projectId);
     Optional<Task> findByProject_IdAndId(Long projectId, Long taskId);
-    List<Task> findByAssignedUserId(Long id);
+    //List<Task> findByAssignedUserId(Long id);
     Optional<Task> findByTitle(String taskTitle);
 }

--- a/backend/src/main/java/com/collab/taskmanager/service/ProjectService.java
+++ b/backend/src/main/java/com/collab/taskmanager/service/ProjectService.java
@@ -65,7 +65,7 @@ public class ProjectService {
         List<TeamMember> members = teamMembersRepo.findByTeamId(team.getId());
         HashMap<String, List<String>> userTasks = new HashMap<>();
         for (TeamMember member : members) {
-            List<Task> tasks = taskRepo.findByAssignedUserId(member.getMember().getId());
+            List<Task> tasks = taskRepo.findByAssignedUser_IdAndProject_Id(member.getMember().getId(), projectId);
             List<String> tasksNames = tasks.stream().map(Task::getTitle).toList();
             userTasks.put(member.getMember().getName(), tasksNames);
         }

--- a/backend/src/main/java/com/collab/taskmanager/service/TaskService.java
+++ b/backend/src/main/java/com/collab/taskmanager/service/TaskService.java
@@ -87,7 +87,7 @@ public class TaskService {
 
         taskPermissionService.validateTeamMember(project.getTeam().getId(),currentUser.getUser().getId());
 
-        return taskRepo.findAllByProjectId(projectId,pageable)
+        return taskRepo.findAllByProject_Id(projectId,pageable)
                 .map(task -> new GetTaskResponse(
                         task.getId(),
                         task.getTitle(),


### PR DESCRIPTION
Added minor changes which were suggested to fix the bug (tasks showing across different project). Namely added a method List<Task> findByAssignedUser_IdAndProject_Id(Long userId, Long projectId) and changed a method findAllByProject_Id name in TaskRepo.